### PR TITLE
Fixes permissions on the compressed files

### DIFF
--- a/logwriter.go
+++ b/logwriter.go
@@ -477,7 +477,7 @@ func copyFile(fromName, toName string, compressExt string, doCompress bool, errf
 
 		for {
 			// create file with extension .zip
-			if zipFile, err = os.OpenFile(zipFileName, os.O_WRONLY|os.O_CREATE, 0); err != nil {
+			if zipFile, err = os.OpenFile(zipFileName, os.O_WRONLY|os.O_CREATE, 0600); err != nil {
 				break
 			}
 


### PR DESCRIPTION
The compressed files are created with zero permission flags. This complicates manipulations with the compressed files. The patch fixes the problem by setting the file permissions to 0600 (-rw-------)